### PR TITLE
update for notify user

### DIFF
--- a/src/hooks/player_management/assign_physical_index.cpp
+++ b/src/hooks/player_management/assign_physical_index.cpp
@@ -91,6 +91,8 @@ namespace big
 							plyr->is_modder         = entry->is_modder;
 							plyr->block_join        = entry->block_join;
 							plyr->block_join_reason = entry->block_join_reason;
+							plyr->is_friends        = entry->is_friends;
+							plyr->notify_online     = entry->notify_online;
 
 							if (strcmp(plyr->get_name(), entry->name.data()))
 							{

--- a/src/services/player_database/persistent_player.hpp
+++ b/src/services/player_database/persistent_player.hpp
@@ -51,11 +51,13 @@ namespace big
 		bool block_join           = false;
 		int block_join_reason     = 1;
 		bool is_modder            = false;
+		bool is_friends           = false;
+		bool notify_online        = false;
 		std::unordered_set<int> infractions;
 		std::optional<CommandAccessLevel> command_access_level = std::nullopt;
 		PlayerOnlineStatus online_state                        = PlayerOnlineStatus::UNKNOWN;
 
-		NLOHMANN_DEFINE_TYPE_INTRUSIVE_WITH_DEFAULT(persistent_player, name, rockstar_id, block_join, block_join_reason, is_modder, infractions, command_access_level)
+		NLOHMANN_DEFINE_TYPE_INTRUSIVE_WITH_DEFAULT(persistent_player, name, rockstar_id, block_join, block_join_reason, is_modder, is_friends, notify_online, infractions, command_access_level)
 	};
 
 };

--- a/src/services/player_database/player_database_service.cpp
+++ b/src/services/player_database/player_database_service.cpp
@@ -200,7 +200,14 @@ namespace big
 					{
 						it->second->online_state = PlayerOnlineStatus::OFFLINE;
 						if (online[i] == 1)
+						{
 							it->second->online_state = PlayerOnlineStatus::ONLINE;
+							if (it->second->notify_online)
+							{
+								g_notification_service->push_warning("Player Online Notification",
+								    std::format("{} is now online!", it->second->name));
+							}
+						}
 					}
 				}
 			}

--- a/src/services/players/player.hpp
+++ b/src/services/players/player.hpp
@@ -78,6 +78,8 @@ namespace big
 		int block_join_reason          = 0;
 		bool is_spammer                = false;
 		bool is_admin                  = false;
+		bool is_friends                = false;
+		bool notify_online             = false;
 		std::optional<std::uint32_t> player_time_value;
 		std::optional<std::chrono::time_point<std::chrono::system_clock, std::chrono::milliseconds>> player_time_value_received_time;
 		std::optional<std::uint32_t> time_difference;

--- a/src/views/network/view_player_database.cpp
+++ b/src/views/network/view_player_database.cpp
@@ -15,30 +15,60 @@ namespace big
 	char search[64];
 	std::shared_ptr<persistent_player> current_player;
 
+	int filterIndex             = 0;
+	const char* filterOptions[] = {"All", "Friends", "Modders", "Blocked", "Command Level Access", "Notify Online", "Not classified"};
+
 	void draw_player_db_entry(std::shared_ptr<persistent_player> player, const std::string& lower_search)
 	{
 		std::string name = player->name;
 		std::transform(name.begin(), name.end(), name.begin(), ::tolower);
-
+		bool isBlocked = player->block_join;
+		bool isFriend  = player->is_friends;
+		bool isModder  = player->is_modder;
+		
+		ImVec4 onlineColor  = ImVec4(0.0f, 1.0f, 0.0f, 1.0f); // Green
+		ImVec4 offlineColor = ImVec4(0.7f, 0.7f, 0.7f, 1.0f); // Light grey
+		ImVec4 backgroundColor = ImVec4(0.0f, 0.0f, 0.0f, 0.0f);
+		
+		if (isBlocked)
+		    backgroundColor = ImVec4(1.000f, 0.000f, 0.000f, 0.900f); // Red
+		else if (isFriend)
+			backgroundColor = ImVec4(0.031f, 0.347f, 0.706f, 0.902f); // Blue
+		else if (isModder) 
+			backgroundColor = ImVec4(1.0f, 0.5f, 0.0f, 1.0f); //Orange
+			
 		if (lower_search.empty() || name.find(lower_search) != std::string::npos)
 		{
 			ImGui::PushID(player->rockstar_id);
 
-			float circle_size = 7.5f;
+			float circle_size = 10.0f;
 			auto cursor_pos   = ImGui::GetCursorScreenPos();
 			auto plyr_state   = player->online_state;
 
 			//render status circle
 			ImGui::GetWindowDrawList()->AddCircleFilled(ImVec2(cursor_pos.x + 4.f + circle_size, cursor_pos.y + 4.f + circle_size),
-				circle_size,
-				ImColor(plyr_state == PlayerOnlineStatus::ONLINE  ? ImVec4(0.f, 1.f, 0.f, 1.f) :
-						plyr_state == PlayerOnlineStatus::OFFLINE ? ImVec4(1.f, 0.f, 0.f, 1.f) :
-						plyr_state == PlayerOnlineStatus::UNKNOWN ? ImVec4(.5f, .5f, .5f, 1.0f) :
-																	ImVec4(.5f, .5f, .5f, 1.0f)));
+			    circle_size,
+			    ImColor(plyr_state == PlayerOnlineStatus::ONLINE  ? onlineColor :
+						plyr_state == PlayerOnlineStatus::OFFLINE ? offlineColor :
+			            plyr_state == PlayerOnlineStatus::UNKNOWN ? ImVec4(.5f, .5f, .5f, 1.0f) :   
+			                                                        ImVec4(.5f, .5f, .5f, 1.0f))); 
+
+			// Render additional circles for blocked, friends, and modders
+			if (isBlocked)
+				ImGui::GetWindowDrawList()->AddCircleFilled(ImVec2(cursor_pos.x + 4.f + circle_size, cursor_pos.y + 4.f + circle_size),
+					circle_size - 3.0f, ImColor(backgroundColor));
+
+			if (isFriend)
+				ImGui::GetWindowDrawList()->AddCircleFilled(ImVec2(cursor_pos.x + 4.f + circle_size, cursor_pos.y + 4.f + circle_size),
+					circle_size - 3.0f, ImColor(backgroundColor));
+
+			if (isModder)
+				ImGui::GetWindowDrawList()->AddCircleFilled(ImVec2(cursor_pos.x + 4.f + circle_size, cursor_pos.y + 4.f + circle_size),
+					circle_size - 3.0f, ImColor(backgroundColor));
 
 			//we need some padding
 			ImVec2 cursor = ImGui::GetCursorPos();
-			ImGui::SetCursorPos(ImVec2(cursor.x + 25.f, cursor.y));
+			ImGui::SetCursorPos(ImVec2(cursor.x + 30.f, cursor.y));
 
 			if (components::selectable(player->name, player == g_player_database_service->get_selected()))
 			{
@@ -48,15 +78,19 @@ namespace big
 			}
 
 			ImGui::PopID();
+		
 		}
 	}
 
 	void view::player_database()
 	{
-
 		ImGui::SetNextItemWidth(300.f);
 		components::input_text_with_hint("PLAYER"_T, "SEARCH"_T, search, sizeof(search), ImGuiInputTextFlags_None);
-
+		ImGui::SetNextItemWidth(300.f);
+		ImGui::Combo("##filterCombo", &filterIndex, filterOptions, IM_ARRAYSIZE(filterOptions));
+		ImGui::SameLine();
+		ImGui::Text("Filter");
+				
 		if (ImGui::ListBoxHeader("###players", {180, static_cast<float>(*g_pointers->m_gta.m_resolution_y - 400 - 38 * 4)}))
 		{
 			auto& item_arr = g_player_database_service->get_sorted_players();
@@ -64,23 +98,103 @@ namespace big
 			{
 				std::string lower_search = search;
 				std::transform(lower_search.begin(), lower_search.end(), lower_search.begin(), tolower);
-
+				
+				// Loop through the players, considering online state and filtering
 				for (auto& player : item_arr | std::ranges::views::values)
 				{
-					if (player->online_state == PlayerOnlineStatus::ONLINE)
+					// Check if the player meets the filtering criteria
+					bool isFiltered = false;
+					switch (filterIndex)
+					{
+					case 0: // All
+						break;
+					case 1: // Friends
+						if (!player->is_friends)
+							isFiltered = true;
+						break;
+					case 2: // Modders
+						if (!player->is_modder)
+							isFiltered = true;
+						break;
+					case 3: // Blocked
+						if (!player->block_join)
+							isFiltered = true;
+					case 4: // Command level access
+						if (!player->command_access_level.has_value()
+							|| (player->command_access_level != CommandAccessLevel::FRIENDLY 
+							&& player->command_access_level != CommandAccessLevel::AGGRESSIVE
+						    && player->command_access_level != CommandAccessLevel::TOXIC 
+							&& player->command_access_level != CommandAccessLevel::ADMIN))
+							isFiltered = true;
+						break;
+					case 5: // Notify Online
+						if (!player->notify_online)
+							isFiltered = true;
+						break;
+					case 6: // Not classified as modder, friend, blocked, or notify 
+						if (player->is_modder || player->is_friends || player->block_join || player->notify_online)
+							isFiltered = true;
+						break;
+					}
+
+					// Draw the player entry if it's not filtered and online
+					if (!isFiltered && player->online_state == PlayerOnlineStatus::ONLINE)
 						draw_player_db_entry(player, lower_search);
 				}
 
+				ImGui::Separator();
+
+				// Loop through the players again for offline entries
 				for (auto& player : item_arr | std::ranges::views::values)
 				{
-					if (player->online_state != PlayerOnlineStatus::ONLINE)
+					// Check if the player meets the filtering criteria
+					bool isFiltered = false;
+					switch (filterIndex)
+					{
+					case 0: // All
+						break;
+					case 1: // Friends
+						if (!player->is_friends)
+							isFiltered = true;
+						break;
+					case 2: // Modders
+						if (!player->is_modder)
+							isFiltered = true;
+						break;
+					case 3: // Blocked
+						if (!player->block_join)
+							isFiltered = true;
+						break;
+					case 4: // Command level access
+						if (!player->command_access_level.has_value() 
+							|| (player->command_access_level != CommandAccessLevel::FRIENDLY 
+							&& player->command_access_level != CommandAccessLevel::AGGRESSIVE
+							&& player->command_access_level != CommandAccessLevel::TOXIC 
+							&& player->command_access_level != CommandAccessLevel::ADMIN))
+     						isFiltered = true;
+						break;
+					case 5: // Notify Online
+						if (!player->notify_online)
+							isFiltered = true;
+						break;
+					case 6: // Not classified as modder, friend, blocked, or notify
+						if (player->is_modder || player->is_friends || player->block_join || player->notify_online)
+							isFiltered = true;
+						break;
+					}
+
+					// Draw the player entry if it's not filtered and offline
+					if (!isFiltered && player->online_state != PlayerOnlineStatus::ONLINE)
 						draw_player_db_entry(player, lower_search);
 				}
+
+				ImGui::PopStyleColor();
 			}
 			else
 			{
 				ImGui::Text("NO_STORED_PLAYERS"_T.data());
 			}
+
 
 			ImGui::ListBoxFooter();
 		}
@@ -95,7 +209,11 @@ namespace big
 					current_player->name = name_buf;
 				}
 
-				if (ImGui::InputScalar("RID"_T.data(), ImGuiDataType_S64, &current_player->rockstar_id) || ImGui::Checkbox("IS_MODDER"_T.data(), &current_player->is_modder) || ImGui::Checkbox("BLOCK_JOIN"_T.data(), &current_player->block_join))
+				if (ImGui::InputScalar("RID"_T.data(), ImGuiDataType_S64, &current_player->rockstar_id)
+				    || ImGui::Checkbox("Notify When Online"_T.data(), &current_player->notify_online)
+				    || ImGui::Checkbox("IS_FRIENDS"_T.data(), &current_player->is_friends)
+				    || ImGui::Checkbox("IS_MODDER"_T.data(), &current_player->is_modder)
+				    || ImGui::Checkbox("BLOCK_JOIN"_T.data(), &current_player->block_join))
 				{
 					if (current_player->rockstar_id != selected->rockstar_id)
 						g_player_database_service->update_rockstar_id(selected->rockstar_id, current_player->rockstar_id);

--- a/src/views/players/view_players.cpp
+++ b/src/views/players/view_players.cpp
@@ -15,6 +15,9 @@ namespace big
 	static void player_button(const player_ptr& plyr)
 	{
 		bool selected_player = plyr == g_player_service->get_selected();
+		bool isFriend        = plyr->is_friends;
+		bool isModder        = plyr->is_modder;
+		bool isBlocked       = plyr->block_join;
 
 		// generate icons string
 		std::string player_icons;
@@ -22,6 +25,10 @@ namespace big
 			player_icons += FONT_ICON_HOST;
 		if (plyr->is_friend())
 			player_icons += FONT_ICON_FRIEND;
+		if (plyr->is_friends)
+			player_icons += FONT_ICON_FRIEND;
+		if (plyr->block_join)
+			player_icons += FONT_ICON_NOTFRIEND;
 		if (const auto ped = plyr->get_ped(); ped != nullptr && ped->m_ped_task_flag & (uint8_t)ePedTask::TASK_DRIVING)
 			player_icons += FONT_ICON_VEHICLE;
 
@@ -38,14 +45,21 @@ namespace big
 
 		if (plyr->is_admin)
 			ImGui::PushStyleColor(ImGuiCol_Button, ImVec4(1.f, 0.67f, 0.f, 1.f));
+		else if (plyr->block_join)
+			ImGui::PushStyleColor(ImGuiCol_Button, ImVec4(1.000f, 0.000f, 0.000f, 0.900f)); // Red
+		else if (plyr->is_friend())
+			ImGui::PushStyleColor(ImGuiCol_Button, ImVec4(0.031f, 0.347f, 0.706f, 0.902f)); // Blue
+		else if (plyr->is_friends)
+			ImGui::PushStyleColor(ImGuiCol_Button, ImVec4(0.031f, 0.347f, 0.706f, 0.902f)); // Blue
 		else if (plyr->is_modder)
-			ImGui::PushStyleColor(ImGuiCol_Button, ImVec4(1.f, 0.1f, 0.1f, 1.f));
+			ImGui::PushStyleColor(ImGuiCol_Button, ImVec4(1.0f, 0.5f, 0.0f, 1.0f)); //Orange
 
 		if (selected_player)
 			ImGui::PushStyleColor(ImGuiCol_Button, ImVec4(0.29f, 0.45f, 0.69f, 1.f));
 
 		ImGui::PushStyleVar(ImGuiStyleVar_ButtonTextAlign, {0.0, 0.5});
 		ImGui::PushID(plyr->id());
+
 		if (ImGui::Button(plyr->get_name(), {300.0f - ImGui::GetStyle().ScrollbarSize, 0.f}))
 		{
 			g_player_service->set_selected(plyr);
@@ -58,8 +72,9 @@ namespace big
 		if (selected_player)
 			ImGui::PopStyleColor();
 
-		if (plyr->is_admin || plyr->is_modder)
-			ImGui::PopStyleColor();
+		if (plyr->is_admin && plyr->is_friends || plyr->is_modder || plyr->block_join)
+		    
+		ImGui::PopStyleColor();
 
 		// render icons on top of the player button
 		ImGui::PushFont(g.window.font_icon);
@@ -84,7 +99,8 @@ namespace big
 		if (ImGui::Begin("playerlist", nullptr, window_flags))
 		{
 			float window_height = (ImGui::CalcTextSize("A").y + ImGui::GetStyle().ItemInnerSpacing.y * 2 + 6.0f) * player_count + 10.0f;
-			window_height = window_height + window_pos > (float)*g_pointers->m_gta.m_resolution_y - 10.f ? (float)*g_pointers->m_gta.m_resolution_y - (window_pos + 40.f) : window_height;
+			window_height =
+			    window_height + window_pos > (float)*g_pointers->m_gta.m_resolution_y - 10.f ? (float)*g_pointers->m_gta.m_resolution_y - (window_pos + 40.f) : window_height;
 
 			ImGui::PushStyleColor(ImGuiCol_FrameBg, {0.f, 0.f, 0.f, 0.f});
 			ImGui::PushStyleColor(ImGuiCol_ScrollbarBg, {0.f, 0.f, 0.f, 0.f});


### PR DESCRIPTION
adds colors to player list player DB
and friends to PDB only with online status
and online notify from rxan 
with notice in circle
red blocked 
blue friends
orange modders

filters in PDB
friends
modders
blocked
command level access
notify online
and people that are unclassed but in the PDB
same colors apply 
friends, modders, blocked
no colors for CLA or NO
theres no onhover or selected player or player colors the status is in the overlayed circle

also adds player icons for friends you select as in PDB as well as R* friends 
also added icon for non-friends ie. blocked in PDB for those that get by and still manage to join will have a head with a x in it and be red

this should about cover it 

if they select to many as notify you will get a flood of notices when it updates every idk 5mins i guess i didnt change 
any thing for that 

